### PR TITLE
Excluded the name and logo from the license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -3,7 +3,7 @@ MIT License
 Copyright (c) 2018 Lasse Nørfeldt
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
+of this software and associated documentation files (EXCEPT NAME AND LOGO), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
@@ -19,3 +19,4 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+


### PR DESCRIPTION
Wish to retain trademark rights to name and logo. Removing it from the license just means that you must ask me if you wish to use the name and logo.